### PR TITLE
Add operator< for GeoID so it can be a std::map key

### DIFF
--- a/include/dfmessages/GeoID.hpp
+++ b/include/dfmessages/GeoID.hpp
@@ -10,6 +10,7 @@
 #define DFMESSAGES_INCLUDE_DFMESSAGES_GEOID_HPP_
 
 #include <cstdint>
+#include <tuple>
 
 namespace dunedaq {
 namespace dfmessages {
@@ -17,6 +18,11 @@ struct GeoID
 {
   uint32_t APANumber;  // NOLINT(build/unsigned)
   uint32_t LinkNumber; // NOLINT(build/unsigned)
+
+  bool operator<(const GeoID& other) const
+  {
+    return std::tuple(APANumber, LinkNumber) < std::tuple(other.APANumber, other.LinkNumber);
+  }
 };
 } // namespace dfmessages
 } // namespace dunedaq


### PR DESCRIPTION
TriggerDecision has a `std::map<GeoID, ComponentRequest>` so we need an `operator<` for GeoID.